### PR TITLE
 The reference of iterator must be given

### DIFF
--- a/behavioral/iterator_test.go
+++ b/behavioral/iterator_test.go
@@ -11,7 +11,7 @@ func TestIterator(t *testing.T) {
 
 	iterator := ArrayIterator{array, 0}
 
-	for it := iterator; iterator.HasNext(); iterator.Next() {
+	for it := &iterator; iterator.HasNext(); iterator.Next() {
 		index, value := it.Index(), it.Value().(float64)
 		if value != array[index] {
 			t.Errorf("Expected array value to equal %v, but received %v", array[index], value)


### PR DESCRIPTION
when the pass array value to different variable u should pass the referance ,
last version of test pass value but .Next() up to value of iterator variable ,When pass the referance the iterator test going right way