### PR TITLE
Upgrade to go 1.19.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gofmt
     - goimports
@@ -14,9 +13,7 @@ linters:
     - misspell
     - nakedret
     - staticcheck
-    - structcheck
     - unused
-    - varcheck
     - whitespace
 
 linter-settings:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ os:
   
 go: 
   - "1.19.x"
-  - tip
 
 install:
   - echo $PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   
 go: 
-  - "1.17.x"
+  - "1.19.x"
   - tip
 
 install:
@@ -12,7 +12,7 @@ install:
   - echo $GOPATH
   - go version
   - go env
-  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
+  - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0
 
 script:
  - ./test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ build: off
 
 clone_folder: c:\github.com\bvwells\go-patterns
 
-stack: go 1.17.1
+stack: go 1.19.1
 
 install:
   - echo %PATH%

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/bvwells/go-patterns
 
-go 1.17
+go 1.19
 
-require github.com/stretchr/testify v1.2.2
+require github.com/stretchr/testify v1.8.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- Upgrade to go 1.19.1
- Upgrade dependencies
- Upgrade golangci-lint to 1.49.1